### PR TITLE
Composer: require PHP >=8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "type": "library",
   "license": "MIT",
   "require": {
-    "php": "^8.2",
+    "php": ">=8.2",
     "nette/di": "^3.2.6",
     "nette/schema": "^1.3.5",
     "thepay/api-client": "^3.0.0"


### PR DESCRIPTION
Updates the root Composer PHP requirement from `^8.2` to `>=8.2`.